### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/skeleton/${{ "app-insights.tf" if values.enable_app_insights else "" }}
+++ b/skeleton/${{ "app-insights.tf" if values.enable_app_insights else "" }}
@@ -1,5 +1,5 @@
 module "application_insights" {
-  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
+  source   = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
   env      = var.env
   product  = var.product
   location = var.location


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.