### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/skeleton/${{ "app-insights.tf" if values.enable_app_insights else "" }}
+++ b/skeleton/${{ "app-insights.tf" if values.enable_app_insights else "" }}
@@ -15,5 +15,6 @@ moved {
 }
 
 output "appInsightsInstrumentationKey" {
-  value = module.application_insights.instrumentation_key
+  value     = module.application_insights.instrumentation_key
+  sensitive = true
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.